### PR TITLE
Custom tag and field property name formatters

### DIFF
--- a/src/RendleLabs.InfluxDB.DiagnosticSourceListener/DiagnosticListenerOptions.cs
+++ b/src/RendleLabs.InfluxDB.DiagnosticSourceListener/DiagnosticListenerOptions.cs
@@ -8,11 +8,16 @@ namespace RendleLabs.InfluxDB.DiagnosticSourceListener
     public class DiagnosticListenerOptions
     {
         private readonly DefaultTags _defaultTags = new DefaultTags();
-        
+
         public Dictionary<(string, Type), Func<PropertyInfo, IFormatter>> CustomFieldFormatters { get; } = new Dictionary<(string, Type), Func<PropertyInfo, IFormatter>>();
         public Dictionary<(string, Type), Func<PropertyInfo, IFormatter>> CustomTagFormatters { get; } = new Dictionary<(string, Type), Func<PropertyInfo, IFormatter>>();
-        
+
         public Func<string, string> NameFixer { get; set; }
+
+        public Func<string, string> TagNameFormatter { get; set; }
+
+        public Func<string, string> FieldNameFormatter { get; set; }
+
         public Action<DiagnosticListener, Exception> OnError { get; set; }
 
         public byte[] DefaultTags => _defaultTags.Bytes;
@@ -23,7 +28,7 @@ namespace RendleLabs.InfluxDB.DiagnosticSourceListener
             if (propertyType == null) throw new ArgumentNullException(nameof(propertyType));
             CustomFieldFormatters[(propertyName, propertyType)] = formatter ?? throw new ArgumentNullException(nameof(formatter));
         }
-        
+
         public void AddCustomFieldFormatter(Type propertyType, Func<PropertyInfo, IFormatter> formatter)
         {
             AddCustomFieldFormatter(string.Empty, propertyType, formatter);

--- a/src/RendleLabs.InfluxDB.DiagnosticSourceListener/FieldFormatter.cs
+++ b/src/RendleLabs.InfluxDB.DiagnosticSourceListener/FieldFormatter.cs
@@ -7,9 +7,9 @@ namespace RendleLabs.InfluxDB.DiagnosticSourceListener
 {
     internal static class FieldFormatter // : IFormatter
     {
-        public static IFormatter TryCreate(PropertyInfo property)
+        public static IFormatter TryCreate(PropertyInfo property, Func<string, string> propertyNameFormatter)
         {
-            return TypedFormatter.Create(property);
+            return TypedFormatter.Create(property, propertyNameFormatter);
         }
         internal static bool IsFieldType(Type type) => FieldTypes.Contains(type);
 

--- a/src/RendleLabs.InfluxDB.DiagnosticSourceListener/InfluxLineFormatter.cs
+++ b/src/RendleLabs.InfluxDB.DiagnosticSourceListener/InfluxLineFormatter.cs
@@ -8,8 +8,8 @@ namespace RendleLabs.InfluxDB.DiagnosticSourceListener
 {
     internal class InfluxLineFormatter : ILineWriter
     {
-        private const byte Newline = (byte) '\n';
-        private const byte Space = (byte) ' ';
+        private const byte Newline = (byte)'\n';
+        private const byte Space = (byte)' ';
 
         private readonly byte[] _measurement;
         private readonly int _measurementLength;
@@ -19,14 +19,12 @@ namespace RendleLabs.InfluxDB.DiagnosticSourceListener
         private readonly bool _hasDefaultTags;
         private readonly int _baseLength;
 
-        internal InfluxLineFormatter(string measurement, Type argsType,
-            Dictionary<(string, Type), Func<PropertyInfo, IFormatter>> customFieldFormatters,
-            Dictionary<(string, Type), Func<PropertyInfo, IFormatter>> customTagFormatters, byte[] optionsDefaultTags)
+        internal InfluxLineFormatter(string measurement, Type argsType, DiagnosticListenerOptions options)
         {
             _measurement = InfluxName.Escape(measurement);
             _measurementLength = _measurement.Length;
-            _objectFormatter = new ObjectFormatter(argsType, customFieldFormatters, customTagFormatters);
-            _defaultTags = optionsDefaultTags;
+            _objectFormatter = new ObjectFormatter(argsType, options);
+            _defaultTags = options.DefaultTags;
             _hasDefaultTags = _defaultTags != null && (_defaultTagsLength = _defaultTags.Length) > 0;
 
             _baseLength = _measurementLength + _defaultTagsLength + 2;
@@ -78,12 +76,12 @@ namespace RendleLabs.InfluxDB.DiagnosticSourceListener
 
             span[0] = Newline;
             bytesWritten = _baseLength + written + timestampWritten;
-            
+
             LongestWritten = Math.Max(LongestWritten, bytesWritten);
-            
+
             return true;
 
-            fail:
+        fail:
             bytesWritten = 0;
             return false;
         }
@@ -92,4 +90,3 @@ namespace RendleLabs.InfluxDB.DiagnosticSourceListener
     }
 }
 
-    

--- a/src/RendleLabs.InfluxDB.DiagnosticSourceListener/InfluxLineFormatterCollection.cs
+++ b/src/RendleLabs.InfluxDB.DiagnosticSourceListener/InfluxLineFormatterCollection.cs
@@ -26,7 +26,6 @@ namespace RendleLabs.InfluxDB.DiagnosticSourceListener
         }
 
         private InfluxLineFormatter Create((string measurementName, Type type) args) =>
-            new InfluxLineFormatter(_nameFixer($"{_listenerName}_{args.measurementName}"), args.type,
-                _options.CustomFieldFormatters, _options.CustomTagFormatters, _options.DefaultTags);
+            new InfluxLineFormatter(_nameFixer($"{_listenerName}_{args.measurementName}"), args.type, _options);
     }
 }

--- a/src/RendleLabs.InfluxDB.DiagnosticSourceListener/NameFixer.cs
+++ b/src/RendleLabs.InfluxDB.DiagnosticSourceListener/NameFixer.cs
@@ -6,7 +6,8 @@ namespace RendleLabs.InfluxDB.DiagnosticSourceListener
     internal static class NameFixer
     {
         public static Func<string, string> Default { get; } = DefaultFixer;
-        
+        public static Func<string, string> Identity { get; } = id => id;
+
         private static readonly Regex Fix = new Regex(@"[\W]+");
         private static string DefaultFixer(string original) => Fix.Replace(original ?? string.Empty, "_");
     }

--- a/src/RendleLabs.InfluxDB.DiagnosticSourceListener/TagFormatter.cs
+++ b/src/RendleLabs.InfluxDB.DiagnosticSourceListener/TagFormatter.cs
@@ -7,15 +7,15 @@ namespace RendleLabs.InfluxDB.DiagnosticSourceListener
 {
     internal static class TagFormatter
     {
-        public static IFormatter TryCreate(PropertyInfo property)
+        public static IFormatter TryCreate(PropertyInfo property, Func<string, string> propertyNameFormatter)
         {
-            if (property.PropertyType == typeof(string)) return new StringTagFormatter(property);
-            if (property.PropertyType == typeof(DateTime)) return new DateTimeTagFormatter(property);
-            if (property.PropertyType == typeof(DateTime?)) return new NullableDateTimeTagFormatter(property);
-            if (property.PropertyType == typeof(DateTimeOffset)) return new DateTimeOffsetTagFormatter(property);
-            if (property.PropertyType == typeof(DateTimeOffset?)) return new NullableDateTimeOffsetTagFormatter(property);
-            if (property.PropertyType == typeof(Guid)) return new GuidTagFormatter(property);
-            if (property.PropertyType == typeof(Guid?)) return new NullableGuidTagFormatter(property);
+            if (property.PropertyType == typeof(string)) return new StringTagFormatter(property, propertyNameFormatter);
+            if (property.PropertyType == typeof(DateTime)) return new DateTimeTagFormatter(property, propertyNameFormatter);
+            if (property.PropertyType == typeof(DateTime?)) return new NullableDateTimeTagFormatter(property, propertyNameFormatter);
+            if (property.PropertyType == typeof(DateTimeOffset)) return new DateTimeOffsetTagFormatter(property, propertyNameFormatter);
+            if (property.PropertyType == typeof(DateTimeOffset?)) return new NullableDateTimeOffsetTagFormatter(property, propertyNameFormatter);
+            if (property.PropertyType == typeof(Guid)) return new GuidTagFormatter(property, propertyNameFormatter);
+            if (property.PropertyType == typeof(Guid?)) return new NullableGuidTagFormatter(property, propertyNameFormatter);
             return null;
         }
 

--- a/src/RendleLabs.InfluxDB.DiagnosticSourceListener/TypedFormatters/BooleanFieldFormatter.cs
+++ b/src/RendleLabs.InfluxDB.DiagnosticSourceListener/TypedFormatters/BooleanFieldFormatter.cs
@@ -5,7 +5,8 @@ namespace RendleLabs.InfluxDB.DiagnosticSourceListener.TypedFormatters
 {
     internal class BooleanFieldFormatter : TypedFormatter<bool>, IFormatter
     {
-        public BooleanFieldFormatter(PropertyInfo property) : base(property)
+        public BooleanFieldFormatter(PropertyInfo property, Func<string, string> propertyNameFormatter)
+            : base(property, propertyNameFormatter)
         {
         }
 

--- a/src/RendleLabs.InfluxDB.DiagnosticSourceListener/TypedFormatters/ByteFieldFormatter.cs
+++ b/src/RendleLabs.InfluxDB.DiagnosticSourceListener/TypedFormatters/ByteFieldFormatter.cs
@@ -5,7 +5,8 @@ namespace RendleLabs.InfluxDB.DiagnosticSourceListener.TypedFormatters
 {
     internal class ByteFieldFormatter : TypedFormatter<byte>, IFormatter
     {
-        public ByteFieldFormatter(PropertyInfo property) : base(property)
+        public ByteFieldFormatter(PropertyInfo property, Func<string, string> propertyNameFormatter)
+            : base(property, propertyNameFormatter)
         {
         }
 

--- a/src/RendleLabs.InfluxDB.DiagnosticSourceListener/TypedFormatters/DateTimeOffsetTagFormatter.cs
+++ b/src/RendleLabs.InfluxDB.DiagnosticSourceListener/TypedFormatters/DateTimeOffsetTagFormatter.cs
@@ -5,7 +5,8 @@ namespace RendleLabs.InfluxDB.DiagnosticSourceListener.TypedFormatters
 {
     internal class DateTimeOffsetTagFormatter : TypedFormatter<DateTimeOffset>, IFormatter
     {
-        public DateTimeOffsetTagFormatter(PropertyInfo property) : base(property)
+        public DateTimeOffsetTagFormatter(PropertyInfo property, Func<string, string> propertyNameFormatter)
+            : base(property, propertyNameFormatter)
         {
         }
 

--- a/src/RendleLabs.InfluxDB.DiagnosticSourceListener/TypedFormatters/DateTimeTagFormatter.cs
+++ b/src/RendleLabs.InfluxDB.DiagnosticSourceListener/TypedFormatters/DateTimeTagFormatter.cs
@@ -5,7 +5,8 @@ namespace RendleLabs.InfluxDB.DiagnosticSourceListener.TypedFormatters
 {
     internal class DateTimeTagFormatter : TypedFormatter<DateTime>, IFormatter
     {
-        public DateTimeTagFormatter(PropertyInfo property) : base(property)
+        public DateTimeTagFormatter(PropertyInfo property, Func<string, string> propertyNameFormatter)
+            : base(property, propertyNameFormatter)
         {
         }
 

--- a/src/RendleLabs.InfluxDB.DiagnosticSourceListener/TypedFormatters/DecimalFieldFormatter.cs
+++ b/src/RendleLabs.InfluxDB.DiagnosticSourceListener/TypedFormatters/DecimalFieldFormatter.cs
@@ -5,7 +5,8 @@ namespace RendleLabs.InfluxDB.DiagnosticSourceListener.TypedFormatters
 {
     internal class DecimalFieldFormatter : TypedFormatter<decimal>, IFormatter
     {
-        public DecimalFieldFormatter(PropertyInfo property) : base(property)
+        public DecimalFieldFormatter(PropertyInfo property, Func<string, string> propertyNameFormatter)
+            : base(property, propertyNameFormatter)
         {
         }
 

--- a/src/RendleLabs.InfluxDB.DiagnosticSourceListener/TypedFormatters/DoubleFieldFormatter.cs
+++ b/src/RendleLabs.InfluxDB.DiagnosticSourceListener/TypedFormatters/DoubleFieldFormatter.cs
@@ -5,7 +5,8 @@ namespace RendleLabs.InfluxDB.DiagnosticSourceListener.TypedFormatters
 {
     internal class DoubleFieldFormatter : TypedFormatter<double>, IFormatter
     {
-        public DoubleFieldFormatter(PropertyInfo property) : base(property)
+        public DoubleFieldFormatter(PropertyInfo property, Func<string, string> propertyNameFormatter)
+            : base(property, propertyNameFormatter)
         {
         }
 

--- a/src/RendleLabs.InfluxDB.DiagnosticSourceListener/TypedFormatters/FloatFieldFormatter.cs
+++ b/src/RendleLabs.InfluxDB.DiagnosticSourceListener/TypedFormatters/FloatFieldFormatter.cs
@@ -5,7 +5,8 @@ namespace RendleLabs.InfluxDB.DiagnosticSourceListener.TypedFormatters
 {
     internal class SingleFieldFormatter : TypedFormatter<float>, IFormatter
     {
-        public SingleFieldFormatter(PropertyInfo property) : base(property)
+        public SingleFieldFormatter(PropertyInfo property, Func<string, string> propertyNameFormatter)
+            : base(property, propertyNameFormatter)
         {
         }
 

--- a/src/RendleLabs.InfluxDB.DiagnosticSourceListener/TypedFormatters/GuidFieldFormatter.cs
+++ b/src/RendleLabs.InfluxDB.DiagnosticSourceListener/TypedFormatters/GuidFieldFormatter.cs
@@ -5,7 +5,8 @@ namespace RendleLabs.InfluxDB.DiagnosticSourceListener.TypedFormatters
 {
     internal class GuidFieldFormatter : TypedFormatter<Guid>, IFormatter
     {
-        public GuidFieldFormatter(PropertyInfo property) : base(property)
+        public GuidFieldFormatter(PropertyInfo property, Func<string, string> propertyNameFormatter)
+            : base(property, propertyNameFormatter)
         {
         }
 

--- a/src/RendleLabs.InfluxDB.DiagnosticSourceListener/TypedFormatters/GuidTagFormatter.cs
+++ b/src/RendleLabs.InfluxDB.DiagnosticSourceListener/TypedFormatters/GuidTagFormatter.cs
@@ -5,7 +5,8 @@ namespace RendleLabs.InfluxDB.DiagnosticSourceListener.TypedFormatters
 {
     internal class GuidTagFormatter : TypedFormatter<Guid>, IFormatter
     {
-        public GuidTagFormatter(PropertyInfo property) : base(property)
+        public GuidTagFormatter(PropertyInfo property, Func<string, string> propertyNameFormatter)
+            : base(property, propertyNameFormatter)
         {
         }
 

--- a/src/RendleLabs.InfluxDB.DiagnosticSourceListener/TypedFormatters/Int16FieldFormatter.cs
+++ b/src/RendleLabs.InfluxDB.DiagnosticSourceListener/TypedFormatters/Int16FieldFormatter.cs
@@ -5,7 +5,8 @@ namespace RendleLabs.InfluxDB.DiagnosticSourceListener.TypedFormatters
 {
     internal class Int16FieldFormatter : TypedFormatter<short>, IFormatter
     {
-        public Int16FieldFormatter(PropertyInfo property) : base(property)
+        public Int16FieldFormatter(PropertyInfo property, Func<string, string> propertyNameFormatter)
+            : base(property, propertyNameFormatter)
         {
         }
 

--- a/src/RendleLabs.InfluxDB.DiagnosticSourceListener/TypedFormatters/Int32FieldFormatter.cs
+++ b/src/RendleLabs.InfluxDB.DiagnosticSourceListener/TypedFormatters/Int32FieldFormatter.cs
@@ -5,7 +5,8 @@ namespace RendleLabs.InfluxDB.DiagnosticSourceListener.TypedFormatters
 {
     internal class Int32FieldFormatter : TypedFormatter<int>, IFormatter
     {
-        public Int32FieldFormatter(PropertyInfo property) : base(property)
+        public Int32FieldFormatter(PropertyInfo property, Func<string, string> propertyNameFormatter)
+            : base(property, propertyNameFormatter)
         {
         }
 

--- a/src/RendleLabs.InfluxDB.DiagnosticSourceListener/TypedFormatters/Int64FieldFormatter.cs
+++ b/src/RendleLabs.InfluxDB.DiagnosticSourceListener/TypedFormatters/Int64FieldFormatter.cs
@@ -5,7 +5,8 @@ namespace RendleLabs.InfluxDB.DiagnosticSourceListener.TypedFormatters
 {
     internal class Int64FieldFormatter : TypedFormatter<long>, IFormatter
     {
-        public Int64FieldFormatter(PropertyInfo property) : base(property)
+        public Int64FieldFormatter(PropertyInfo property, Func<string, string> propertyNameFormatter)
+            : base(property, propertyNameFormatter)
         {
         }
 

--- a/src/RendleLabs.InfluxDB.DiagnosticSourceListener/TypedFormatters/NullableBooleanFieldFormatter.cs
+++ b/src/RendleLabs.InfluxDB.DiagnosticSourceListener/TypedFormatters/NullableBooleanFieldFormatter.cs
@@ -5,7 +5,8 @@ namespace RendleLabs.InfluxDB.DiagnosticSourceListener.TypedFormatters
 {
     internal class NullableBooleanFieldFormatter : TypedFormatter<bool?>, IFormatter
     {
-        public NullableBooleanFieldFormatter(PropertyInfo property) : base(property)
+        public NullableBooleanFieldFormatter(PropertyInfo property, Func<string, string> propertyNameFormatter)
+            : base(property, propertyNameFormatter)
         {
         }
 

--- a/src/RendleLabs.InfluxDB.DiagnosticSourceListener/TypedFormatters/NullableByteFieldFormatter.cs
+++ b/src/RendleLabs.InfluxDB.DiagnosticSourceListener/TypedFormatters/NullableByteFieldFormatter.cs
@@ -5,7 +5,8 @@ namespace RendleLabs.InfluxDB.DiagnosticSourceListener.TypedFormatters
 {
     internal class NullableByteFieldFormatter : TypedFormatter<byte?>, IFormatter
     {
-        public NullableByteFieldFormatter(PropertyInfo property) : base(property)
+        public NullableByteFieldFormatter(PropertyInfo property, Func<string, string> propertyNameFormatter)
+            : base(property, propertyNameFormatter)
         {
         }
 

--- a/src/RendleLabs.InfluxDB.DiagnosticSourceListener/TypedFormatters/NullableDateTimeOffsetTagFormatter.cs
+++ b/src/RendleLabs.InfluxDB.DiagnosticSourceListener/TypedFormatters/NullableDateTimeOffsetTagFormatter.cs
@@ -5,7 +5,8 @@ namespace RendleLabs.InfluxDB.DiagnosticSourceListener.TypedFormatters
 {
     internal class NullableDateTimeOffsetTagFormatter : TypedFormatter<DateTimeOffset?>, IFormatter
     {
-        public NullableDateTimeOffsetTagFormatter(PropertyInfo property) : base(property)
+        public NullableDateTimeOffsetTagFormatter(PropertyInfo property, Func<string, string> propertyNameFormatter)
+            : base(property, propertyNameFormatter)
         {
         }
 

--- a/src/RendleLabs.InfluxDB.DiagnosticSourceListener/TypedFormatters/NullableDateTimeTagFormatter.cs
+++ b/src/RendleLabs.InfluxDB.DiagnosticSourceListener/TypedFormatters/NullableDateTimeTagFormatter.cs
@@ -5,7 +5,8 @@ namespace RendleLabs.InfluxDB.DiagnosticSourceListener.TypedFormatters
 {
     internal class NullableDateTimeTagFormatter : TypedFormatter<DateTime?>, IFormatter
     {
-        public NullableDateTimeTagFormatter(PropertyInfo property) : base(property)
+        public NullableDateTimeTagFormatter(PropertyInfo property, Func<string, string> propertyNameFormatter)
+            : base(property, propertyNameFormatter)
         {
         }
 

--- a/src/RendleLabs.InfluxDB.DiagnosticSourceListener/TypedFormatters/NullableDecimalFieldFormatter.cs
+++ b/src/RendleLabs.InfluxDB.DiagnosticSourceListener/TypedFormatters/NullableDecimalFieldFormatter.cs
@@ -5,7 +5,8 @@ namespace RendleLabs.InfluxDB.DiagnosticSourceListener.TypedFormatters
 {
     internal class NullableDecimalFieldFormatter : TypedFormatter<decimal?>, IFormatter
     {
-        public NullableDecimalFieldFormatter(PropertyInfo property) : base(property)
+        public NullableDecimalFieldFormatter(PropertyInfo property, Func<string, string> propertyNameFormatter)
+            : base(property, propertyNameFormatter)
         {
         }
 

--- a/src/RendleLabs.InfluxDB.DiagnosticSourceListener/TypedFormatters/NullableDoubleFieldFormatter.cs
+++ b/src/RendleLabs.InfluxDB.DiagnosticSourceListener/TypedFormatters/NullableDoubleFieldFormatter.cs
@@ -5,7 +5,8 @@ namespace RendleLabs.InfluxDB.DiagnosticSourceListener.TypedFormatters
 {
     internal class NullableDoubleFieldFormatter : TypedFormatter<double?>, IFormatter
     {
-        public NullableDoubleFieldFormatter(PropertyInfo property) : base(property)
+        public NullableDoubleFieldFormatter(PropertyInfo property, Func<string, string> propertyNameFormatter)
+            : base(property, propertyNameFormatter)
         {
         }
 

--- a/src/RendleLabs.InfluxDB.DiagnosticSourceListener/TypedFormatters/NullableGuidFieldFormatter.cs
+++ b/src/RendleLabs.InfluxDB.DiagnosticSourceListener/TypedFormatters/NullableGuidFieldFormatter.cs
@@ -5,7 +5,8 @@ namespace RendleLabs.InfluxDB.DiagnosticSourceListener.TypedFormatters
 {
     internal class NullableGuidFieldFormatter : TypedFormatter<Guid?>, IFormatter
     {
-        public NullableGuidFieldFormatter(PropertyInfo property) : base(property)
+        public NullableGuidFieldFormatter(PropertyInfo property, Func<string, string> propertyNameFormatter)
+            : base(property, propertyNameFormatter)
         {
         }
 

--- a/src/RendleLabs.InfluxDB.DiagnosticSourceListener/TypedFormatters/NullableGuidTagFormatter.cs
+++ b/src/RendleLabs.InfluxDB.DiagnosticSourceListener/TypedFormatters/NullableGuidTagFormatter.cs
@@ -5,7 +5,8 @@ namespace RendleLabs.InfluxDB.DiagnosticSourceListener.TypedFormatters
 {
     internal class NullableGuidTagFormatter : TypedFormatter<Guid?>, IFormatter
     {
-        public NullableGuidTagFormatter(PropertyInfo property) : base(property)
+        public NullableGuidTagFormatter(PropertyInfo property, Func<string, string> propertyNameFormatter)
+            : base(property, propertyNameFormatter)
         {
         }
 

--- a/src/RendleLabs.InfluxDB.DiagnosticSourceListener/TypedFormatters/NullableInt16FieldFormatter.cs
+++ b/src/RendleLabs.InfluxDB.DiagnosticSourceListener/TypedFormatters/NullableInt16FieldFormatter.cs
@@ -5,7 +5,8 @@ namespace RendleLabs.InfluxDB.DiagnosticSourceListener.TypedFormatters
 {
     internal class NullableInt16FieldFormatter : TypedFormatter<short?>, IFormatter
     {
-        public NullableInt16FieldFormatter(PropertyInfo property) : base(property)
+        public NullableInt16FieldFormatter(PropertyInfo property, Func<string, string> propertyNameFormatter)
+            : base(property, propertyNameFormatter)
         {
         }
 

--- a/src/RendleLabs.InfluxDB.DiagnosticSourceListener/TypedFormatters/NullableInt32FieldFormatter.cs
+++ b/src/RendleLabs.InfluxDB.DiagnosticSourceListener/TypedFormatters/NullableInt32FieldFormatter.cs
@@ -5,7 +5,8 @@ namespace RendleLabs.InfluxDB.DiagnosticSourceListener.TypedFormatters
 {
     internal class NullableInt32FieldFormatter : TypedFormatter<int?>, IFormatter
     {
-        public NullableInt32FieldFormatter(PropertyInfo property) : base(property)
+        public NullableInt32FieldFormatter(PropertyInfo property, Func<string, string> propertyNameFormatter)
+            : base(property, propertyNameFormatter)
         {
         }
 

--- a/src/RendleLabs.InfluxDB.DiagnosticSourceListener/TypedFormatters/NullableInt64FieldFormatter.cs
+++ b/src/RendleLabs.InfluxDB.DiagnosticSourceListener/TypedFormatters/NullableInt64FieldFormatter.cs
@@ -5,7 +5,8 @@ namespace RendleLabs.InfluxDB.DiagnosticSourceListener.TypedFormatters
 {
     internal class NullableInt64FieldFormatter : TypedFormatter<long?>, IFormatter
     {
-        public NullableInt64FieldFormatter(PropertyInfo property) : base(property)
+        public NullableInt64FieldFormatter(PropertyInfo property, Func<string, string> propertyNameFormatter)
+            : base(property, propertyNameFormatter)
         {
         }
 

--- a/src/RendleLabs.InfluxDB.DiagnosticSourceListener/TypedFormatters/NullableSByteFieldFormatter.cs
+++ b/src/RendleLabs.InfluxDB.DiagnosticSourceListener/TypedFormatters/NullableSByteFieldFormatter.cs
@@ -5,7 +5,8 @@ namespace RendleLabs.InfluxDB.DiagnosticSourceListener.TypedFormatters
 {
     internal class NullableSByteFieldFormatter : TypedFormatter<sbyte?>, IFormatter
     {
-        public NullableSByteFieldFormatter(PropertyInfo property) : base(property)
+        public NullableSByteFieldFormatter(PropertyInfo property, Func<string, string> propertyNameFormatter)
+            : base(property, propertyNameFormatter)
         {
         }
 

--- a/src/RendleLabs.InfluxDB.DiagnosticSourceListener/TypedFormatters/NullableSingleFieldFormatter.cs
+++ b/src/RendleLabs.InfluxDB.DiagnosticSourceListener/TypedFormatters/NullableSingleFieldFormatter.cs
@@ -5,7 +5,8 @@ namespace RendleLabs.InfluxDB.DiagnosticSourceListener.TypedFormatters
 {
     internal class NullableSingleFieldFormatter : TypedFormatter<float?>, IFormatter
     {
-        public NullableSingleFieldFormatter(PropertyInfo property) : base(property)
+        public NullableSingleFieldFormatter(PropertyInfo property, Func<string, string> propertyNameFormatter)
+            : base(property, propertyNameFormatter)
         {
         }
 

--- a/src/RendleLabs.InfluxDB.DiagnosticSourceListener/TypedFormatters/NullableTimeSpanFieldFormatter.cs
+++ b/src/RendleLabs.InfluxDB.DiagnosticSourceListener/TypedFormatters/NullableTimeSpanFieldFormatter.cs
@@ -5,7 +5,8 @@ namespace RendleLabs.InfluxDB.DiagnosticSourceListener.TypedFormatters
 {
     internal class NullableTimeSpanFieldFormatter : TypedFormatter<TimeSpan?>, IFormatter
     {
-        public NullableTimeSpanFieldFormatter(PropertyInfo property) : base(property)
+        public NullableTimeSpanFieldFormatter(PropertyInfo property, Func<string, string> propertyNameFormatter)
+            : base(property, propertyNameFormatter)
         {
         }
 

--- a/src/RendleLabs.InfluxDB.DiagnosticSourceListener/TypedFormatters/NullableUInt16FieldFormatter.cs
+++ b/src/RendleLabs.InfluxDB.DiagnosticSourceListener/TypedFormatters/NullableUInt16FieldFormatter.cs
@@ -5,7 +5,8 @@ namespace RendleLabs.InfluxDB.DiagnosticSourceListener.TypedFormatters
 {
     internal class NullableUInt16FieldFormatter : TypedFormatter<ushort?>, IFormatter
     {
-        public NullableUInt16FieldFormatter(PropertyInfo property) : base(property)
+        public NullableUInt16FieldFormatter(PropertyInfo property, Func<string, string> propertyNameFormatter)
+            : base(property, propertyNameFormatter)
         {
         }
 

--- a/src/RendleLabs.InfluxDB.DiagnosticSourceListener/TypedFormatters/NullableUInt32FieldFormatter.cs
+++ b/src/RendleLabs.InfluxDB.DiagnosticSourceListener/TypedFormatters/NullableUInt32FieldFormatter.cs
@@ -5,7 +5,8 @@ namespace RendleLabs.InfluxDB.DiagnosticSourceListener.TypedFormatters
 {
     internal class NullableUInt32FieldFormatter : TypedFormatter<uint?>, IFormatter
     {
-        public NullableUInt32FieldFormatter(PropertyInfo property) : base(property)
+        public NullableUInt32FieldFormatter(PropertyInfo property, Func<string, string> propertyNameFormatter)
+            : base(property, propertyNameFormatter)
         {
         }
 

--- a/src/RendleLabs.InfluxDB.DiagnosticSourceListener/TypedFormatters/NullableUInt64FieldFormatter.cs
+++ b/src/RendleLabs.InfluxDB.DiagnosticSourceListener/TypedFormatters/NullableUInt64FieldFormatter.cs
@@ -5,7 +5,8 @@ namespace RendleLabs.InfluxDB.DiagnosticSourceListener.TypedFormatters
 {
     internal class NullableUInt64FieldFormatter : TypedFormatter<ulong?>, IFormatter
     {
-        public NullableUInt64FieldFormatter(PropertyInfo property) : base(property)
+        public NullableUInt64FieldFormatter(PropertyInfo property, Func<string, string> propertyNameFormatter)
+            : base(property, propertyNameFormatter)
         {
         }
 

--- a/src/RendleLabs.InfluxDB.DiagnosticSourceListener/TypedFormatters/SByteFieldFormatter.cs
+++ b/src/RendleLabs.InfluxDB.DiagnosticSourceListener/TypedFormatters/SByteFieldFormatter.cs
@@ -5,7 +5,8 @@ namespace RendleLabs.InfluxDB.DiagnosticSourceListener.TypedFormatters
 {
     internal class SByteFieldFormatter : TypedFormatter<sbyte>, IFormatter
     {
-        public SByteFieldFormatter(PropertyInfo property) : base(property)
+        public SByteFieldFormatter(PropertyInfo property, Func<string, string> propertyNameFormatter)
+            : base(property, propertyNameFormatter)
         {
         }
 

--- a/src/RendleLabs.InfluxDB.DiagnosticSourceListener/TypedFormatters/StringTagFormatter.cs
+++ b/src/RendleLabs.InfluxDB.DiagnosticSourceListener/TypedFormatters/StringTagFormatter.cs
@@ -5,7 +5,8 @@ namespace RendleLabs.InfluxDB.DiagnosticSourceListener.TypedFormatters
 {
     internal class StringTagFormatter : TypedFormatter<string>, IFormatter
     {
-        public StringTagFormatter(PropertyInfo property) : base(property)
+        public StringTagFormatter(PropertyInfo property, Func<string, string> propertyNameFormatter)
+            : base(property, propertyNameFormatter)
         {
         }
 

--- a/src/RendleLabs.InfluxDB.DiagnosticSourceListener/TypedFormatters/TimeSpanFieldFormatter.cs
+++ b/src/RendleLabs.InfluxDB.DiagnosticSourceListener/TypedFormatters/TimeSpanFieldFormatter.cs
@@ -5,7 +5,8 @@ namespace RendleLabs.InfluxDB.DiagnosticSourceListener.TypedFormatters
 {
     internal class TimeSpanFieldFormatter : TypedFormatter<TimeSpan>, IFormatter
     {
-        public TimeSpanFieldFormatter(PropertyInfo property) : base(property)
+        public TimeSpanFieldFormatter(PropertyInfo property, Func<string, string> propertyNameFormatter)
+            : base(property, propertyNameFormatter)
         {
         }
 

--- a/src/RendleLabs.InfluxDB.DiagnosticSourceListener/TypedFormatters/TypedFormatter.cs
+++ b/src/RendleLabs.InfluxDB.DiagnosticSourceListener/TypedFormatters/TypedFormatter.cs
@@ -5,36 +5,36 @@ namespace RendleLabs.InfluxDB.DiagnosticSourceListener.TypedFormatters
 {
     internal static class TypedFormatter
     {
-        internal static IFormatter Create(PropertyInfo property)
+        internal static IFormatter Create(PropertyInfo property, Func<string, string> propertyNameFormatter)
         {
-            if (property.PropertyType == typeof(bool)) return new BooleanFieldFormatter(property);
-            if (property.PropertyType == typeof(bool?)) return new NullableBooleanFieldFormatter(property);
-            if (property.PropertyType == typeof(byte)) return new ByteFieldFormatter(property);
-            if (property.PropertyType == typeof(byte?)) return new NullableByteFieldFormatter(property);
-            if (property.PropertyType == typeof(decimal)) return new DecimalFieldFormatter(property);
-            if (property.PropertyType == typeof(decimal?)) return new NullableDecimalFieldFormatter(property);
-            if (property.PropertyType == typeof(double)) return new DoubleFieldFormatter(property);
-            if (property.PropertyType == typeof(double?)) return new NullableDoubleFieldFormatter(property);
-            if (property.PropertyType == typeof(Guid)) return new GuidFieldFormatter(property);
-            if (property.PropertyType == typeof(Guid?)) return new NullableGuidFieldFormatter(property);
-            if (property.PropertyType == typeof(short)) return new Int16FieldFormatter(property);
-            if (property.PropertyType == typeof(short?)) return new NullableInt16FieldFormatter(property);
-            if (property.PropertyType == typeof(int)) return new Int32FieldFormatter(property);
-            if (property.PropertyType == typeof(int?)) return new NullableInt32FieldFormatter(property);
-            if (property.PropertyType == typeof(long)) return new Int64FieldFormatter(property);
-            if (property.PropertyType == typeof(long?)) return new NullableInt64FieldFormatter(property);
-            if (property.PropertyType == typeof(ushort)) return new UInt16FieldFormatter(property);
-            if (property.PropertyType == typeof(ushort?)) return new NullableUInt16FieldFormatter(property);
-            if (property.PropertyType == typeof(uint)) return new UInt32FieldFormatter(property);
-            if (property.PropertyType == typeof(uint?)) return new NullableUInt32FieldFormatter(property);
-            if (property.PropertyType == typeof(ulong)) return new UInt64FieldFormatter(property);
-            if (property.PropertyType == typeof(ulong?)) return new NullableUInt64FieldFormatter(property);
-            if (property.PropertyType == typeof(sbyte)) return new SByteFieldFormatter(property);
-            if (property.PropertyType == typeof(sbyte?)) return new NullableSByteFieldFormatter(property);
-            if (property.PropertyType == typeof(float)) return new SingleFieldFormatter(property);
-            if (property.PropertyType == typeof(float?)) return new NullableSingleFieldFormatter(property);
-            if (property.PropertyType == typeof(TimeSpan)) return new TimeSpanFieldFormatter(property);
-            if (property.PropertyType == typeof(TimeSpan?)) return new NullableTimeSpanFieldFormatter(property);
+            if (property.PropertyType == typeof(bool)) return new BooleanFieldFormatter(property, propertyNameFormatter);
+            if (property.PropertyType == typeof(bool?)) return new NullableBooleanFieldFormatter(property, propertyNameFormatter);
+            if (property.PropertyType == typeof(byte)) return new ByteFieldFormatter(property, propertyNameFormatter);
+            if (property.PropertyType == typeof(byte?)) return new NullableByteFieldFormatter(property, propertyNameFormatter);
+            if (property.PropertyType == typeof(decimal)) return new DecimalFieldFormatter(property, propertyNameFormatter);
+            if (property.PropertyType == typeof(decimal?)) return new NullableDecimalFieldFormatter(property, propertyNameFormatter);
+            if (property.PropertyType == typeof(double)) return new DoubleFieldFormatter(property, propertyNameFormatter);
+            if (property.PropertyType == typeof(double?)) return new NullableDoubleFieldFormatter(property, propertyNameFormatter);
+            if (property.PropertyType == typeof(Guid)) return new GuidFieldFormatter(property, propertyNameFormatter);
+            if (property.PropertyType == typeof(Guid?)) return new NullableGuidFieldFormatter(property, propertyNameFormatter);
+            if (property.PropertyType == typeof(short)) return new Int16FieldFormatter(property, propertyNameFormatter);
+            if (property.PropertyType == typeof(short?)) return new NullableInt16FieldFormatter(property, propertyNameFormatter);
+            if (property.PropertyType == typeof(int)) return new Int32FieldFormatter(property, propertyNameFormatter);
+            if (property.PropertyType == typeof(int?)) return new NullableInt32FieldFormatter(property, propertyNameFormatter);
+            if (property.PropertyType == typeof(long)) return new Int64FieldFormatter(property, propertyNameFormatter);
+            if (property.PropertyType == typeof(long?)) return new NullableInt64FieldFormatter(property, propertyNameFormatter);
+            if (property.PropertyType == typeof(ushort)) return new UInt16FieldFormatter(property, propertyNameFormatter);
+            if (property.PropertyType == typeof(ushort?)) return new NullableUInt16FieldFormatter(property, propertyNameFormatter);
+            if (property.PropertyType == typeof(uint)) return new UInt32FieldFormatter(property, propertyNameFormatter);
+            if (property.PropertyType == typeof(uint?)) return new NullableUInt32FieldFormatter(property, propertyNameFormatter);
+            if (property.PropertyType == typeof(ulong)) return new UInt64FieldFormatter(property, propertyNameFormatter);
+            if (property.PropertyType == typeof(ulong?)) return new NullableUInt64FieldFormatter(property, propertyNameFormatter);
+            if (property.PropertyType == typeof(sbyte)) return new SByteFieldFormatter(property, propertyNameFormatter);
+            if (property.PropertyType == typeof(sbyte?)) return new NullableSByteFieldFormatter(property, propertyNameFormatter);
+            if (property.PropertyType == typeof(float)) return new SingleFieldFormatter(property, propertyNameFormatter);
+            if (property.PropertyType == typeof(float?)) return new NullableSingleFieldFormatter(property, propertyNameFormatter);
+            if (property.PropertyType == typeof(TimeSpan)) return new TimeSpanFieldFormatter(property, propertyNameFormatter);
+            if (property.PropertyType == typeof(TimeSpan?)) return new NullableTimeSpanFieldFormatter(property, propertyNameFormatter);
             return null;
         }
     }

--- a/src/RendleLabs.InfluxDB.DiagnosticSourceListener/TypedFormatters/TypedFormatterOfT.cs
+++ b/src/RendleLabs.InfluxDB.DiagnosticSourceListener/TypedFormatters/TypedFormatterOfT.cs
@@ -9,15 +9,16 @@ namespace RendleLabs.InfluxDB.DiagnosticSourceListener.TypedFormatters
         protected readonly Func<object, T> Getter;
         protected readonly byte[] Name;
 
-        protected TypedFormatter(PropertyInfo property)
+        protected TypedFormatter(PropertyInfo property, Func<string, string> propertyNameFormatter)
         {
             if (property == null) throw new ArgumentNullException(nameof(property));
             if (property.DeclaringType == null) throw new InvalidOperationException();
+            if (propertyNameFormatter == null) throw new ArgumentNullException(nameof(propertyNameFormatter));
 
             var parameter = Expression.Parameter(typeof(object));
             var get = Expression.Property(Expression.Convert(parameter, property.DeclaringType), property);
             Getter = Expression.Lambda<Func<object, T>>(get, parameter).Compile();
-            Name = InfluxName.Escape(property.Name);
+            Name = InfluxName.Escape(propertyNameFormatter(property.Name));
         }
     }
 }

--- a/src/RendleLabs.InfluxDB.DiagnosticSourceListener/TypedFormatters/UInt16FieldFormatter.cs
+++ b/src/RendleLabs.InfluxDB.DiagnosticSourceListener/TypedFormatters/UInt16FieldFormatter.cs
@@ -5,7 +5,8 @@ namespace RendleLabs.InfluxDB.DiagnosticSourceListener.TypedFormatters
 {
     internal class UInt16FieldFormatter : TypedFormatter<ushort>, IFormatter
     {
-        public UInt16FieldFormatter(PropertyInfo property) : base(property)
+        public UInt16FieldFormatter(PropertyInfo property, Func<string, string> propertyNameFormatter)
+            : base(property, propertyNameFormatter)
         {
         }
 

--- a/src/RendleLabs.InfluxDB.DiagnosticSourceListener/TypedFormatters/UInt32FieldFormatter.cs
+++ b/src/RendleLabs.InfluxDB.DiagnosticSourceListener/TypedFormatters/UInt32FieldFormatter.cs
@@ -5,7 +5,8 @@ namespace RendleLabs.InfluxDB.DiagnosticSourceListener.TypedFormatters
 {
     internal class UInt32FieldFormatter : TypedFormatter<uint>, IFormatter
     {
-        public UInt32FieldFormatter(PropertyInfo property) : base(property)
+        public UInt32FieldFormatter(PropertyInfo property, Func<string, string> propertyNameFormatter)
+            : base(property, propertyNameFormatter)
         {
         }
 

--- a/src/RendleLabs.InfluxDB.DiagnosticSourceListener/TypedFormatters/UInt64FieldFormatter.cs
+++ b/src/RendleLabs.InfluxDB.DiagnosticSourceListener/TypedFormatters/UInt64FieldFormatter.cs
@@ -5,7 +5,8 @@ namespace RendleLabs.InfluxDB.DiagnosticSourceListener.TypedFormatters
 {
     internal class UInt64FieldFormatter : TypedFormatter<ulong>, IFormatter
     {
-        public UInt64FieldFormatter(PropertyInfo property) : base(property)
+        public UInt64FieldFormatter(PropertyInfo property, Func<string, string> propertyNameFormatter)
+            : base(property, propertyNameFormatter)
         {
         }
 

--- a/test/RendleLabs.InfluxDB.DiagnosticSourceListener.Tests/CustomFieldFormatterTests.cs
+++ b/test/RendleLabs.InfluxDB.DiagnosticSourceListener.Tests/CustomFieldFormatterTests.cs
@@ -12,11 +12,9 @@ namespace RendleLabs.InfluxDB.DiagnosticSourceListener.Tests
         public void FormatsCustomField()
         {
             var args = new {custom = new CustomObject {Value = 42, Thing = "foo"}};
-            Dictionary<(string, Type), Func<PropertyInfo, IFormatter>> cff = new Dictionary<(string, Type), Func<PropertyInfo, IFormatter>>
-            {
-                [("custom", typeof(CustomObject))] = p => new CustomObjectFieldFormatter(p)
-            };
-            var objectFormatter = new ObjectFormatter(args.GetType(), cff, null);
+            var options = new DiagnosticListenerOptions();
+            options.AddCustomFieldFormatter("custom", typeof(CustomObject), p => new CustomObjectFieldFormatter(p));
+            var objectFormatter = new ObjectFormatter(args.GetType(), options);
             var buffer = new byte[128];
             var span = buffer.AsSpan();
             Assert.True(objectFormatter.Write(args, null, span, out int written));
@@ -28,15 +26,10 @@ namespace RendleLabs.InfluxDB.DiagnosticSourceListener.Tests
         public void FormatsCustomFieldAndTag()
         {
             var args = new {custom = new CustomObject {Value = 42, Thing = "foo"}};
-            Dictionary<(string, Type), Func<PropertyInfo, IFormatter>> cff = new Dictionary<(string, Type), Func<PropertyInfo, IFormatter>>
-            {
-                [("custom", typeof(CustomObject))] = p => new CustomObjectFieldFormatter(p)
-            };
-            Dictionary<(string, Type), Func<PropertyInfo, IFormatter>> ctf = new Dictionary<(string, Type), Func<PropertyInfo, IFormatter>>
-            {
-                [("custom", typeof(CustomObject))] = p => new CustomObjectTagFormatter(p)
-            };
-            var objectFormatter = new ObjectFormatter(args.GetType(), cff, ctf);
+            var options = new DiagnosticListenerOptions();
+            options.AddCustomFieldFormatter("custom", typeof(CustomObject), p => new CustomObjectFieldFormatter(p));
+            options.AddCustomTagFormatter("custom", typeof(CustomObject), p => new CustomObjectTagFormatter(p));
+            var objectFormatter = new ObjectFormatter(args.GetType(), options);
             var buffer = new byte[128];
             var span = buffer.AsSpan();
             Assert.True(objectFormatter.Write(args, null, span, out int written));

--- a/test/RendleLabs.InfluxDB.DiagnosticSourceListener.Tests/DecimalFieldFormatterTests.cs
+++ b/test/RendleLabs.InfluxDB.DiagnosticSourceListener.Tests/DecimalFieldFormatterTests.cs
@@ -10,7 +10,7 @@ namespace RendleLabs.InfluxDB.DiagnosticSourceListener.Tests
         public void FormatsDecimalCorrectly()
         {
             var args = new {foo = 42m};
-            var formatter = FieldFormatter.TryCreate(args.GetType().GetProperty("foo"));
+            var formatter = FieldFormatter.TryCreate(args.GetType().GetProperty("foo"), NameFixer.Identity);
             var buffer = new byte[64];
             Assert.True(formatter.TryWrite(args, buffer.AsSpan(), false, out int written));
             Assert.Equal(6, written);
@@ -23,7 +23,7 @@ namespace RendleLabs.InfluxDB.DiagnosticSourceListener.Tests
         {
             decimal? foo = 42m;
             var args = new {foo};
-            var formatter = FieldFormatter.TryCreate(args.GetType().GetProperty("foo"));
+            var formatter = FieldFormatter.TryCreate(args.GetType().GetProperty("foo"), NameFixer.Identity);
             var buffer = new byte[64];
             Assert.True(formatter.TryWrite(args, buffer.AsSpan(), false, out int written));
             Assert.Equal(6, written);

--- a/test/RendleLabs.InfluxDB.DiagnosticSourceListener.Tests/FieldFormatterTests.cs
+++ b/test/RendleLabs.InfluxDB.DiagnosticSourceListener.Tests/FieldFormatterTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Text;
 using Xunit;
 
@@ -6,186 +7,202 @@ namespace RendleLabs.InfluxDB.DiagnosticSourceListener.Tests
 {
     public class FieldFormatterTests
     {
-        [Fact]
-        public void FormatsNullableInt16()
+        public static IEnumerable<object[]> TestNameFormatters = new[] { new[] { NameFixer.Identity }, new[] { (Func<string, string>)(n => n.ToUpperInvariant()) } };
+
+        [Theory]
+        [MemberData(nameof(TestNameFormatters))]
+        public void FormatsNullableInt16(Func<string, string> formatter)
         {
             var obj = new {foo = (short?)42};
             var property = obj.GetType().GetProperty("foo");
-            var target = FieldFormatter.TryCreate(property);
+            var target = FieldFormatter.TryCreate(property, formatter);
             var bytes = new byte[7];
             var span = bytes.AsSpan();
             Assert.True(target.TryWrite(obj, span, false, out int bytesWritten));
             Assert.Equal(7, bytesWritten);
-            Assert.Equal(Encoding.UTF8.GetBytes("foo=42i"), bytes);
+            Assert.Equal(Encoding.UTF8.GetBytes($"{formatter("foo")}=42i"), bytes);
         }
-        
-        [Fact]
-        public void FormatsInt16()
+
+        [Theory]
+        [MemberData(nameof(TestNameFormatters))]
+        public void FormatsInt16(Func<string, string> formatter)
         {
             var obj = new {foo = (short)42};
             var property = obj.GetType().GetProperty("foo");
-            var target = FieldFormatter.TryCreate(property);
+            var target = FieldFormatter.TryCreate(property, formatter);
             var bytes = new byte[7];
             var span = bytes.AsSpan();
             Assert.True(target.TryWrite(obj, span, false, out int bytesWritten));
             Assert.Equal(7, bytesWritten);
-            Assert.Equal(Encoding.UTF8.GetBytes("foo=42i"), bytes);
+            Assert.Equal(Encoding.UTF8.GetBytes($"{formatter("foo")}=42i"), bytes);
         }
-        
-        [Fact]
-        public void FormatsInt32()
+
+        [Theory]
+        [MemberData(nameof(TestNameFormatters))]
+        public void FormatsInt32(Func<string, string> formatter)
         {
             var obj = new {foo = 42};
             var property = obj.GetType().GetProperty("foo");
-            var target = FieldFormatter.TryCreate(property);
+            var target = FieldFormatter.TryCreate(property, formatter);
             var bytes = new byte[7];
             var span = bytes.AsSpan();
             Assert.True(target.TryWrite(obj, span, false, out int bytesWritten));
             Assert.Equal(7, bytesWritten);
-            Assert.Equal(Encoding.UTF8.GetBytes("foo=42i"), bytes);
+            Assert.Equal(Encoding.UTF8.GetBytes($"{formatter("foo")}=42i"), bytes);
         }
-        
-        [Fact]
-        public void FormatsInt64()
+
+        [Theory]
+        [MemberData(nameof(TestNameFormatters))]
+        public void FormatsInt64(Func<string, string> formatter)
         {
             var obj = new {foo = 42L};
             var property = obj.GetType().GetProperty("foo");
-            var target = FieldFormatter.TryCreate(property);
+            var target = FieldFormatter.TryCreate(property, formatter);
             var bytes = new byte[7];
             var span = bytes.AsSpan();
             Assert.True(target.TryWrite(obj, span, false, out int bytesWritten));
             Assert.Equal(7, bytesWritten);
-            Assert.Equal(Encoding.UTF8.GetBytes("foo=42i"), bytes);
+            Assert.Equal(Encoding.UTF8.GetBytes($"{formatter("foo")}=42i"), bytes);
         }
-        
-        [Fact]
-        public void FormatsUInt16()
+
+        [Theory]
+        [MemberData(nameof(TestNameFormatters))]
+        public void FormatsUInt16(Func<string, string> formatter)
         {
             var obj = new {foo = (ushort)42};
             var property = obj.GetType().GetProperty("foo");
-            var target = FieldFormatter.TryCreate(property);
+            var target = FieldFormatter.TryCreate(property, formatter);
             var bytes = new byte[7];
             var span = bytes.AsSpan();
             Assert.True(target.TryWrite(obj, span, false, out int bytesWritten));
             Assert.Equal(7, bytesWritten);
-            Assert.Equal(Encoding.UTF8.GetBytes("foo=42i"), bytes);
+            Assert.Equal(Encoding.UTF8.GetBytes($"{formatter("foo")}=42i"), bytes);
         }
-        
-        [Fact]
-        public void FormatsUInt32()
+
+        [Theory]
+        [MemberData(nameof(TestNameFormatters))]
+        public void FormatsUInt32(Func<string, string> formatter)
         {
             var obj = new {foo = 42u};
             var property = obj.GetType().GetProperty("foo");
-            var target = FieldFormatter.TryCreate(property);
+            var target = FieldFormatter.TryCreate(property, formatter);
             var bytes = new byte[7];
             var span = bytes.AsSpan();
             Assert.True(target.TryWrite(obj, span, false, out int bytesWritten));
             Assert.Equal(7, bytesWritten);
-            Assert.Equal(Encoding.UTF8.GetBytes("foo=42i"), bytes);
+            Assert.Equal(Encoding.UTF8.GetBytes($"{formatter("foo")}=42i"), bytes);
         }
-        
-        [Fact]
-        public void FormatsUInt64()
+
+        [Theory]
+        [MemberData(nameof(TestNameFormatters))]
+        public void FormatsUInt64(Func<string, string> formatter)
         {
             var obj = new {foo = 42ul};
             var property = obj.GetType().GetProperty("foo");
-            var target = FieldFormatter.TryCreate(property);
+            var target = FieldFormatter.TryCreate(property, formatter);
             var bytes = new byte[7];
             var span = bytes.AsSpan();
             Assert.True(target.TryWrite(obj, span, false, out int bytesWritten));
             Assert.Equal(7, bytesWritten);
-            Assert.Equal(Encoding.UTF8.GetBytes("foo=42i"), bytes);
+            Assert.Equal(Encoding.UTF8.GetBytes($"{formatter("foo")}=42i"), bytes);
         }
-        
-        [Fact]
-        public void FormatsByte()
+
+        [Theory]
+        [MemberData(nameof(TestNameFormatters))]
+        public void FormatsByte(Func<string, string> formatter)
         {
             var obj = new {foo = (byte)42};
             var property = obj.GetType().GetProperty("foo");
-            var target = FieldFormatter.TryCreate(property);
+            var target = FieldFormatter.TryCreate(property, formatter);
             var bytes = new byte[7];
             var span = bytes.AsSpan();
             Assert.True(target.TryWrite(obj, span, false, out int bytesWritten));
             Assert.Equal(7, bytesWritten);
-            Assert.Equal(Encoding.UTF8.GetBytes("foo=42i"), bytes);
+            Assert.Equal(Encoding.UTF8.GetBytes($"{formatter("foo")}=42i"), bytes);
         }
-        
-        [Fact]
-        public void FormatsSByte()
+
+        [Theory]
+        [MemberData(nameof(TestNameFormatters))]
+        public void FormatsSByte(Func<string, string> formatter)
         {
             var obj = new {foo = (sbyte)42};
             var property = obj.GetType().GetProperty("foo");
-            var target = FieldFormatter.TryCreate(property);
+            var target = FieldFormatter.TryCreate(property, formatter);
             var bytes = new byte[7];
             var span = bytes.AsSpan();
             Assert.True(target.TryWrite(obj, span, false, out int bytesWritten));
             Assert.Equal(7, bytesWritten);
-            Assert.Equal(Encoding.UTF8.GetBytes("foo=42i"), bytes);
+            Assert.Equal(Encoding.UTF8.GetBytes($"{formatter("foo")}=42i"), bytes);
         }
-        
-        [Fact]
-        public void FormatsSingle()
+
+        [Theory]
+        [MemberData(nameof(TestNameFormatters))]
+        public void FormatsSingle(Func<string, string> formatter)
         {
             var obj = new {foo = 4.2f};
             var property = obj.GetType().GetProperty("foo");
-            var target = FieldFormatter.TryCreate(property);
+            var target = FieldFormatter.TryCreate(property, formatter);
             var bytes = new byte[7];
             var span = bytes.AsSpan();
             Assert.True(target.TryWrite(obj, span, false, out int bytesWritten));
             Assert.Equal(7, bytesWritten);
-            Assert.Equal(Encoding.UTF8.GetBytes("foo=4.2"), bytes);
+            Assert.Equal(Encoding.UTF8.GetBytes($"{formatter("foo")}=4.2"), bytes);
         }
-        
-        [Fact]
-        public void FormatsDouble()
+
+        [Theory]
+        [MemberData(nameof(TestNameFormatters))]
+        public void FormatsDouble(Func<string, string> formatter)
         {
             var obj = new {foo = 4.2};
             var property = obj.GetType().GetProperty("foo");
-            var target = FieldFormatter.TryCreate(property);
+            var target = FieldFormatter.TryCreate(property, formatter);
             var bytes = new byte[7];
             var span = bytes.AsSpan();
             Assert.True(target.TryWrite(obj, span, false, out int bytesWritten));
             Assert.Equal(7, bytesWritten);
-            Assert.Equal(Encoding.UTF8.GetBytes("foo=4.2"), bytes);
+            Assert.Equal(Encoding.UTF8.GetBytes($"{formatter("foo")}=4.2"), bytes);
         }
-        
-        [Fact]
-        public void FormatsDecimal()
+
+        [Theory]
+        [MemberData(nameof(TestNameFormatters))]
+        public void FormatsDecimal(Func<string, string> formatter)
         {
             var obj = new {foo = 4.2m};
             var property = obj.GetType().GetProperty("foo");
-            var target = FieldFormatter.TryCreate(property);
+            var target = FieldFormatter.TryCreate(property, formatter);
             var bytes = new byte[7];
             var span = bytes.AsSpan();
             Assert.True(target.TryWrite(obj, span, false, out int bytesWritten));
             Assert.Equal(7, bytesWritten);
-            Assert.Equal(Encoding.UTF8.GetBytes("foo=4.2"), bytes);
+            Assert.Equal(Encoding.UTF8.GetBytes($"{formatter("foo")}=4.2"), bytes);
         }
-        
-        [Fact]
-        public void FormatsTrue()
+
+        [Theory]
+        [MemberData(nameof(TestNameFormatters))]
+        public void FormatsTrue(Func<string, string> formatter)
         {
             var obj = new {foo = true};
             var property = obj.GetType().GetProperty("foo");
-            var target = FieldFormatter.TryCreate(property);
+            var target = FieldFormatter.TryCreate(property, formatter);
             var bytes = new byte[5];
             var span = bytes.AsSpan();
             Assert.True(target.TryWrite(obj, span, false, out int bytesWritten));
             Assert.Equal(5, bytesWritten);
-            Assert.Equal(Encoding.UTF8.GetBytes("foo=t"), bytes);
+            Assert.Equal(Encoding.UTF8.GetBytes($"{formatter("foo")}=t"), bytes);
         }
-        
-        [Fact]
-        public void FormatsFalse()
+
+        [Theory]
+        [MemberData(nameof(TestNameFormatters))]
+        public void FormatsFalse(Func<string, string> formatter)
         {
             var obj = new {foo = false};
             var property = obj.GetType().GetProperty("foo");
-            var target = FieldFormatter.TryCreate(property);
+            var target = FieldFormatter.TryCreate(property, formatter);
             var bytes = new byte[5];
             var span = bytes.AsSpan();
             Assert.True(target.TryWrite(obj, span, false, out int bytesWritten));
             Assert.Equal(5, bytesWritten);
-            Assert.Equal(Encoding.UTF8.GetBytes("foo=f"), bytes);
+            Assert.Equal(Encoding.UTF8.GetBytes($"{formatter("foo")}=f"), bytes);
         }
     }
 }

--- a/test/RendleLabs.InfluxDB.DiagnosticSourceListener.Tests/ObjectFormatterTests.cs
+++ b/test/RendleLabs.InfluxDB.DiagnosticSourceListener.Tests/ObjectFormatterTests.cs
@@ -13,7 +13,7 @@ namespace RendleLabs.InfluxDB.DiagnosticSourceListener.Tests
             const string expected = ",tag=foo foo=42i";
             
             var obj = new {tag = "foo", foo = 42};
-            var formatter = new ObjectFormatter(obj.GetType(), null, null);
+            var formatter = new ObjectFormatter(obj.GetType(), new DiagnosticListenerOptions());
 
             var memory = ArrayPool<byte>.Shared.Rent(1024);
             var span = memory.AsSpan();
@@ -30,7 +30,27 @@ namespace RendleLabs.InfluxDB.DiagnosticSourceListener.Tests
             const string expected = " foo=42i";
             
             var obj = new {foo = 42};
-            var formatter = new ObjectFormatter(obj.GetType(), null, null);
+            var formatter = new ObjectFormatter(obj.GetType(), new DiagnosticListenerOptions());
+
+            var memory = ArrayPool<byte>.Shared.Rent(1024);
+            var span = memory.AsSpan();
+            formatter.Write(obj, null, span, out int written);
+            var str = Encoding.UTF8.GetString(memory, 0, written);
+            Assert.Equal(expected.Length, written);
+            Assert.Equal(expected, str);
+            ArrayPool<byte>.Shared.Return(memory);
+        }
+
+        [Fact]
+        public void WritesTagsAndFields_WithFormattedNames()
+        {
+            const string expected = ",TAG=foo FOO=42i";
+            var options = new DiagnosticListenerOptions();
+            options.TagNameFormatter = n => n.ToUpperInvariant();
+            options.FieldNameFormatter = n => n.ToUpperInvariant();
+
+            var obj = new { tag = "foo", foo = 42 };
+            var formatter = new ObjectFormatter(obj.GetType(), options);
 
             var memory = ArrayPool<byte>.Shared.Rent(1024);
             var span = memory.AsSpan();

--- a/test/RendleLabs.InfluxDB.DiagnosticSourceListener.Tests/TagFormatterTests.cs
+++ b/test/RendleLabs.InfluxDB.DiagnosticSourceListener.Tests/TagFormatterTests.cs
@@ -9,14 +9,27 @@ namespace RendleLabs.InfluxDB.DiagnosticSourceListener.Tests
         [Fact]
         public void WritesStringTag()
         {
-            var obj = new {foo = "42"};
+            var obj = new { foo = "42" };
             var property = obj.GetType().GetProperty("foo");
-            var target = TagFormatter.TryCreate(property);
+            var target = TagFormatter.TryCreate(property, NameFixer.Identity);
             var bytes = new byte[7];
             var span = bytes.AsSpan();
             target.TryWrite(obj, span, true, out int written);
             Assert.Equal(7, written);
             Assert.Equal(Encoding.UTF8.GetBytes(",foo=42"), bytes);
+        }
+
+        [Fact]
+        public void WritesStringTag_FormatterPropertyName()
+        {
+            var obj = new { foo = "42" };
+            var property = obj.GetType().GetProperty("foo");
+            var target = TagFormatter.TryCreate(property, n => n.ToUpperInvariant());
+            var bytes = new byte[7];
+            var span = bytes.AsSpan();
+            target.TryWrite(obj, span, true, out int written);
+            Assert.Equal(7, written);
+            Assert.Equal(Encoding.UTF8.GetBytes(",FOO=42"), bytes);
         }
     }
 }


### PR DESCRIPTION
Add a way to configure a custom tag and field property name formatters, so property names of non-anonymous classes can be formatted aligned with anonym ones.